### PR TITLE
Fix copyright of all files in the project

### DIFF
--- a/.m2/settings.xml
+++ b/.m2/settings.xml
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright (c) 2018 Feedzai
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+
 <settings>
     <servers>
         <server>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright (c) 2018 Feedzai
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+
 <extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
     <extension>

--- a/.mvn/jgitver.config.xml
+++ b/.mvn/jgitver.config.xml
@@ -1,3 +1,19 @@
+<!--
+  ~ Copyright (c) 2018 Feedzai
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  -->
+
 <configuration xmlns="http://jgitver.github.io/maven/configuration/1.0.0-beta"
                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                xsi:schemaLocation="http://jgitver.github.io/maven/configuration/1.0.0-beta https://jgitver.github.io/maven/configuration/jgitver-configuration-v1_0_0-beta.xsd ">

--- a/openml-generic-python/pom.xml
+++ b/openml-generic-python/pom.xml
@@ -1,12 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ The copyright of this file belongs to Feedzai. The file cannot be
-  ~ reproduced in whole or in part, stored in a retrieval system,
-  ~ transmitted in any form, or by any means electronic, mechanical,
-  ~ photocopying, or otherwise, without the prior permission of the owner.
+  ~ Copyright (c) 2018 Feedzai
   ~
-  ~ (c) 2018 Feedzai, Strictly Confidential
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/openml-generic-python/src/main/java/com/feedzai/openml/python/ClassificationPythonModelLoader.java
+++ b/openml-generic-python/src/main/java/com/feedzai/openml/python/ClassificationPythonModelLoader.java
@@ -1,10 +1,17 @@
 /*
- * The copyright of this file belongs to Feedzai. The file cannot be
- * reproduced in whole or in part, stored in a retrieval system,
- * transmitted in any form, or by any means electronic, mechanical,
- * photocopying, or otherwise, without the prior permission of the owner.
+ * Copyright (c) 2018 Feedzai
  *
- * (c) 2018 Feedzai, Strictly Confidential
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
 package com.feedzai.openml.python;
 

--- a/openml-generic-python/src/main/java/com/feedzai/openml/python/PythonModelProvider.java
+++ b/openml-generic-python/src/main/java/com/feedzai/openml/python/PythonModelProvider.java
@@ -1,10 +1,17 @@
 /*
- * The copyright of this file belongs to Feedzai. The file cannot be
- * reproduced in whole or in part, stored in a retrieval system,
- * transmitted in any form, or by any means electronic, mechanical,
- * photocopying, or otherwise, without the prior permission of the owner.
+ * Copyright (c) 2018 Feedzai
  *
- * (c) 2018 Feedzai, Strictly Confidential
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
 package com.feedzai.openml.python;
 

--- a/openml-generic-python/src/main/java/com/feedzai/openml/python/package-info.java
+++ b/openml-generic-python/src/main/java/com/feedzai/openml/python/package-info.java
@@ -1,10 +1,17 @@
 /*
- * The copyright of this file belongs to Feedzai. The file cannot be
- * reproduced in whole or in part, stored in a retrieval system,
- * transmitted in any form, or by any means electronic, mechanical,
- * photocopying, or otherwise, without the prior permission of the owner.
+ * Copyright (c) 2018 Feedzai
  *
- * (c) 2018 Feedzai, Strictly Confidential
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
 
 /**

--- a/openml-generic-python/src/main/resources/META-INF/services/com.feedzai.openml.provider.MachineLearningProvider
+++ b/openml-generic-python/src/main/resources/META-INF/services/com.feedzai.openml.provider.MachineLearningProvider
@@ -1,9 +1,16 @@
 #
-# The copyright of this file belongs to Feedzai. The file cannot be
-# reproduced in whole or in part, stored in a retrieval system,
-# transmitted in any form, or by any means electronic, mechanical,
-# photocopying, or otherwise, without the prior permission of the owner.
+# Copyright (c) 2018 Feedzai
 #
-# (c) 2018 Feedzai, Strictly Confidential
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 #
 com.feedzai.openml.python.PythonModelProvider

--- a/openml-generic-python/src/test/java/com/feedzai/openml/python/PythonModelProviderTest.java
+++ b/openml-generic-python/src/test/java/com/feedzai/openml/python/PythonModelProviderTest.java
@@ -1,10 +1,17 @@
 /*
- * The copyright of this file belongs to Feedzai. The file cannot be
- * reproduced in whole or in part, stored in a retrieval system,
- * transmitted in any form, or by any means electronic, mechanical,
- * photocopying, or otherwise, without the prior permission of the owner.
+ * Copyright (c) 2018 Feedzai
  *
- * (c) 2018 Feedzai, Strictly Confidential
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
 
 package com.feedzai.openml.python;

--- a/openml-python-common/pom.xml
+++ b/openml-python-common/pom.xml
@@ -1,11 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ The copyright of this file belongs to Feedzai. The file cannot be
-  ~ reproduced in whole or in part, stored in a retrieval system,
-  ~ transmitted in any form, or by any means electronic, mechanical,
-  ~ photocopying, or otherwise, without the prior permission of the owner.
+  ~ Copyright (c) 2018 Feedzai
   ~
-  ~ (c) 2018 Feedzai, Strictly Confidential
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"

--- a/openml-python-common/src/main/java/com/feedzai/openml/python/AbstractClassificationPythonModelLoaderImpl.java
+++ b/openml-python-common/src/main/java/com/feedzai/openml/python/AbstractClassificationPythonModelLoaderImpl.java
@@ -1,10 +1,17 @@
 /*
- * The copyright of this file belongs to Feedzai. The file cannot be
- * reproduced in whole or in part, stored in a retrieval system,
- * transmitted in any form, or by any means electronic, mechanical,
- * photocopying, or otherwise, without the prior permission of the owner.
+ * Copyright (c) 2018 Feedzai
  *
- * (c) 2018 Feedzai, Strictly Confidential
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
 
 package com.feedzai.openml.python;

--- a/openml-python-common/src/main/java/com/feedzai/openml/python/ClassificationPythonModel.java
+++ b/openml-python-common/src/main/java/com/feedzai/openml/python/ClassificationPythonModel.java
@@ -1,10 +1,17 @@
 /*
- * The copyright of this file belongs to Feedzai. The file cannot be
- * reproduced in whole or in part, stored in a retrieval system,
- * transmitted in any form, or by any means electronic, mechanical,
- * photocopying, or otherwise, without the prior permission of the owner.
+ * Copyright (c) 2018 Feedzai
  *
- * (c) 2018 Feedzai, Strictly Confidential
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
 
 package com.feedzai.openml.python;

--- a/openml-python-common/src/main/java/com/feedzai/openml/python/jep/instance/AbstractJepEvaluation.java
+++ b/openml-python-common/src/main/java/com/feedzai/openml/python/jep/instance/AbstractJepEvaluation.java
@@ -1,10 +1,17 @@
 /*
- * The copyright of this file belongs to Feedzai. The file cannot be
- * reproduced in whole or in part, stored in a retrieval system,
- * transmitted in any form, or by any means electronic, mechanical,
- * photocopying, or otherwise, without the prior permission of the owner.
+ * Copyright (c) 2018 Feedzai
  *
- * (c) 2018 Feedzai, Strictly Confidential
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
 package com.feedzai.openml.python.jep.instance;
 

--- a/openml-python-common/src/main/java/com/feedzai/openml/python/jep/instance/JepFunction.java
+++ b/openml-python-common/src/main/java/com/feedzai/openml/python/jep/instance/JepFunction.java
@@ -1,10 +1,17 @@
 /*
- * The copyright of this file belongs to Feedzai. The file cannot be
- * reproduced in whole or in part, stored in a retrieval system,
- * transmitted in any form, or by any means electronic, mechanical,
- * photocopying, or otherwise, without the prior permission of the owner.
+ * Copyright (c) 2018 Feedzai
  *
- * (c) 2018 Feedzai, Strictly Confidential
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
 package com.feedzai.openml.python.jep.instance;
 

--- a/openml-python-common/src/main/java/com/feedzai/openml/python/jep/instance/JepInstance.java
+++ b/openml-python-common/src/main/java/com/feedzai/openml/python/jep/instance/JepInstance.java
@@ -1,10 +1,17 @@
 /*
- * The copyright of this file belongs to Feedzai. The file cannot be
- * reproduced in whole or in part, stored in a retrieval system,
- * transmitted in any form, or by any means electronic, mechanical,
- * photocopying, or otherwise, without the prior permission of the owner.
+ * Copyright (c) 2018 Feedzai
  *
- * (c) 2018 Feedzai, Strictly Confidential
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
 package com.feedzai.openml.python.jep.instance;
 

--- a/openml-python-common/src/main/java/com/feedzai/openml/python/jep/instance/package-info.java
+++ b/openml-python-common/src/main/java/com/feedzai/openml/python/jep/instance/package-info.java
@@ -1,10 +1,17 @@
 /*
- * The copyright of this file belongs to Feedzai. The file cannot be
- * reproduced in whole or in part, stored in a retrieval system,
- * transmitted in any form, or by any means electronic, mechanical,
- * photocopying, or otherwise, without the prior permission of the owner.
+ * Copyright (c) 2018 Feedzai
  *
- * (c) 2018 Feedzai, Strictly Confidential
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
 
 /**

--- a/openml-python-common/src/main/java/com/feedzai/openml/python/package-info.java
+++ b/openml-python-common/src/main/java/com/feedzai/openml/python/package-info.java
@@ -1,10 +1,17 @@
 /*
- * The copyright of this file belongs to Feedzai. The file cannot be
- * reproduced in whole or in part, stored in a retrieval system,
- * transmitted in any form, or by any means electronic, mechanical,
- * photocopying, or otherwise, without the prior permission of the owner.
+ * Copyright (c) 2018 Feedzai
  *
- * (c) 2018 Feedzai, Strictly Confidential
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
 
 /**

--- a/openml-scikit/pom.xml
+++ b/openml-scikit/pom.xml
@@ -1,11 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ The copyright of this file belongs to Feedzai. The file cannot be
-  ~ reproduced in whole or in part, stored in a retrieval system,
-  ~ transmitted in any form, or by any means electronic, mechanical,
-  ~ photocopying, or otherwise, without the prior permission of the owner.
+  ~ Copyright (c) 2018 Feedzai
   ~
-  ~ (c) 2018 Feedzai, Strictly Confidential
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"

--- a/openml-scikit/src/main/java/com/feedzai/openml/scikit/ClassificationScikitModel.java
+++ b/openml-scikit/src/main/java/com/feedzai/openml/scikit/ClassificationScikitModel.java
@@ -1,10 +1,17 @@
 /*
- * The copyright of this file belongs to Feedzai. The file cannot be
- * reproduced in whole or in part, stored in a retrieval system,
- * transmitted in any form, or by any means electronic, mechanical,
- * photocopying, or otherwise, without the prior permission of the owner.
+ * Copyright (c) 2018 Feedzai
  *
- * (c) 2018 Feedzai, Strictly Confidential
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
 
 package com.feedzai.openml.scikit;

--- a/openml-scikit/src/main/java/com/feedzai/openml/scikit/ClassificationScikitModelLoader.java
+++ b/openml-scikit/src/main/java/com/feedzai/openml/scikit/ClassificationScikitModelLoader.java
@@ -1,10 +1,17 @@
 /*
- * The copyright of this file belongs to Feedzai. The file cannot be
- * reproduced in whole or in part, stored in a retrieval system,
- * transmitted in any form, or by any means electronic, mechanical,
- * photocopying, or otherwise, without the prior permission of the owner.
+ * Copyright (c) 2018 Feedzai
  *
- * (c) 2018 Feedzai, Strictly Confidential
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
 
 package com.feedzai.openml.scikit;

--- a/openml-scikit/src/main/java/com/feedzai/openml/scikit/ScikitAlgorithm.java
+++ b/openml-scikit/src/main/java/com/feedzai/openml/scikit/ScikitAlgorithm.java
@@ -1,10 +1,17 @@
 /*
- * The copyright of this file belongs to Feedzai. The file cannot be
- * reproduced in whole or in part, stored in a retrieval system,
- * transmitted in any form, or by any means electronic, mechanical,
- * photocopying, or otherwise, without the prior permission of the owner.
+ * Copyright (c) 2018 Feedzai
  *
- * (c) 2018 Feedzai, Strictly Confidential
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
 package com.feedzai.openml.scikit;
 

--- a/openml-scikit/src/main/java/com/feedzai/openml/scikit/ScikitModelProvider.java
+++ b/openml-scikit/src/main/java/com/feedzai/openml/scikit/ScikitModelProvider.java
@@ -1,10 +1,17 @@
 /*
- * The copyright of this file belongs to Feedzai. The file cannot be
- * reproduced in whole or in part, stored in a retrieval system,
- * transmitted in any form, or by any means electronic, mechanical,
- * photocopying, or otherwise, without the prior permission of the owner.
+ * Copyright (c) 2018 Feedzai
  *
- * (c) 2018 Feedzai, Strictly Confidential
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
 
 package com.feedzai.openml.scikit;

--- a/openml-scikit/src/main/java/com/feedzai/openml/scikit/package-info.java
+++ b/openml-scikit/src/main/java/com/feedzai/openml/scikit/package-info.java
@@ -1,10 +1,17 @@
 /*
- * The copyright of this file belongs to Feedzai. The file cannot be
- * reproduced in whole or in part, stored in a retrieval system,
- * transmitted in any form, or by any means electronic, mechanical,
- * photocopying, or otherwise, without the prior permission of the owner.
+ * Copyright (c) 2018 Feedzai
  *
- * (c) 2018 Feedzai, Strictly Confidential
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
 
 /**

--- a/openml-scikit/src/main/resources/META-INF/services/com.feedzai.openml.provider.MachineLearningProvider
+++ b/openml-scikit/src/main/resources/META-INF/services/com.feedzai.openml.provider.MachineLearningProvider
@@ -1,9 +1,16 @@
 #
-# The copyright of this file belongs to Feedzai. The file cannot be
-# reproduced in whole or in part, stored in a retrieval system,
-# transmitted in any form, or by any means electronic, mechanical,
-# photocopying, or otherwise, without the prior permission of the owner.
+# Copyright (c) 2018 Feedzai
 #
-# (c) 2018 Feedzai, Strictly Confidential
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 #
 com.feedzai.openml.scikit.ScikitModelProvider

--- a/openml-scikit/src/test/java/com/feedzai/openml/scikit/ScikitModelProviderTest.java
+++ b/openml-scikit/src/test/java/com/feedzai/openml/scikit/ScikitModelProviderTest.java
@@ -1,10 +1,17 @@
 /*
- * The copyright of this file belongs to Feedzai. The file cannot be
- * reproduced in whole or in part, stored in a retrieval system,
- * transmitted in any form, or by any means electronic, mechanical,
- * photocopying, or otherwise, without the prior permission of the owner.
+ * Copyright (c) 2018 Feedzai
  *
- * (c) 2018 Feedzai, Strictly Confidential
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
 
 package com.feedzai.openml.scikit;

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ The copyright of this file belongs to Feedzai. The file cannot be
-  ~ reproduced in whole or in part, stored in a retrieval system,
-  ~ transmitted in any form, or by any means electronic, mechanical,
-  ~ photocopying, or otherwise, without the prior permission of the owner.
+  ~ Copyright (c) 2018 Feedzai
   ~
-  ~ (c) 2018 Feedzai, Strictly Confidential
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"


### PR DESCRIPTION
This changes the copyright to abide Apache License V2.0 which
matches the license that we have adopted for the project.

closes #7 