### PR TITLE
Update Openml-api to 0.1.1

### DIFF
--- a/openml-generic-python/src/test/java/com/feedzai/openml/python/PythonModelProviderTest.java
+++ b/openml-generic-python/src/test/java/com/feedzai/openml/python/PythonModelProviderTest.java
@@ -29,6 +29,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.Iterator;
 import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -198,6 +199,14 @@ public class PythonModelProviderTest extends AbstractProviderModelLoadTest<Class
     @Override
     public Instance getDummyInstance() {
         return TEST_DATA_SET.getInstances().next();
+    }
+
+    @Override
+    public Instance getDummyInstanceDifferentResult() {
+        final Iterator<Instance> instances = TEST_DATA_SET.getInstances();
+        // ignores the first instance because it is being used by #getDummyInstance()
+        instances.next();
+        return instances.next();
     }
 
     @Override

--- a/openml-generic-python/src/test/resources/valid_classifier/classifier.py
+++ b/openml-generic-python/src/test/resources/valid_classifier/classifier.py
@@ -1,19 +1,25 @@
 import sys,math
 from ClassifierApi.classifier import ClassifierBase
+import random
+import numpy
 
 class Classifier(ClassifierBase):
 
     num_features=4
     num_classes=3
 
+    def normalize(self, v):
+        norm = numpy.linalg.norm(v, ord=1)
+        if norm == 0:
+            norm = numpy.finfo(v.dtype).eps
+        return v / norm
+
     def classify_instance(self, instance):
         return int(sum(instance) % self.num_classes)
 
     def getClassDistribution_instance(self, instance):
-        i = self.classify_instance(instance)
-        w = 0.6
-        d = [(1 - w) / (self.num_classes - 1)] * self.num_classes
-        d[i] = w
+        random.seed(instance[0])
+        d = self.normalize(random.sample(range(1, 100), self.num_classes))
         return d
 
     def validate(self, instances):
@@ -22,7 +28,6 @@ class Classifier(ClassifierBase):
                 raise Exception('Instance must be an array!')
             if len(instance) != self.num_features:
                 raise Exception('Incorrect number of features in instance! Got {}. Expected {}.'.format(len(instance), self.num_features))
-
 
     def classify(self, instances):
         self.validate(instances)

--- a/openml-scikit/src/test/java/com/feedzai/openml/scikit/ScikitModelProviderTest.java
+++ b/openml-scikit/src/test/java/com/feedzai/openml/scikit/ScikitModelProviderTest.java
@@ -29,6 +29,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.Iterator;
 import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -144,6 +145,14 @@ public class ScikitModelProviderTest extends AbstractProviderModelLoadTest<Class
     @Override
     public Instance getDummyInstance() {
         return TEST_DATA_SET.getInstances().next();
+    }
+
+    @Override
+    public Instance getDummyInstanceDifferentResult() {
+        final Iterator<Instance> instances = TEST_DATA_SET.getInstances();
+        // ignores the first instance because it is being used by #getDummyInstance()
+        instances.next();
+        return instances.next();
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <assertj.version>3.7.0</assertj.version>
         <jackson.version>2.6.7</jackson.version>
         <jackson-databind.version>2.6.7</jackson-databind.version>
-        <openml-api.version>0.1.0</openml-api.version>
+        <openml-api.version>0.1.1</openml-api.version>
         <jep.version>3.7.0</jep.version>
     </properties>
 


### PR DESCRIPTION
In this commit the openML-api is updated to its newest version (0.1.1).
Due to this update I had to improve a script of a generic model to return
values based on the instance to be classify.