### PR TITLE
Validate a model before loading

### DIFF
--- a/openml-python-common/src/main/java/com/feedzai/openml/python/AbstractClassificationPythonModelLoaderImpl.java
+++ b/openml-python-common/src/main/java/com/feedzai/openml/python/AbstractClassificationPythonModelLoaderImpl.java
@@ -26,6 +26,7 @@ import com.feedzai.openml.util.load.LoadSchemaUtils;
 import com.feedzai.openml.util.validate.ClassificationValidationUtils;
 import com.feedzai.openml.util.validate.ValidationUtils;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,6 +60,8 @@ public abstract class AbstractClassificationPythonModelLoaderImpl implements Mac
                                                final DatasetSchema schema) throws ModelLoadingException {
 
         logger.info("Trying to load a model in path [{}]...", modelPath);
+
+        ClassificationValidationUtils.validateParamsModelToLoad(this, modelPath, schema, ImmutableMap.of());
 
         final JepInstance jepInstance = new JepInstance();
         final String id = generateNamesafeId();

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <assertj.version>3.7.0</assertj.version>
         <jackson.version>2.6.7</jackson.version>
         <jackson-databind.version>2.6.7</jackson-databind.version>
-        <openml-api.version>0.2.2</openml-api.version>
+        <openml-api.version>0.3.0</openml-api.version>
         <jep.version>3.7.0</jep.version>
     </properties>
 


### PR DESCRIPTION
When a model is loaded we were assuming that whoever calls it already called the method to validate the model to load which might or not be true. This commit improves the method responsible to load the  model to validate the model before loading  it.