### PR TITLE
Make OpenML dependencies provided so that they are not part of the OpenML uber jars

### DIFF
--- a/openml-generic-python/pom.xml
+++ b/openml-generic-python/pom.xml
@@ -37,6 +37,11 @@
         </dependency>
         <dependency>
             <groupId>com.feedzai</groupId>
+            <artifactId>openml-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.feedzai</groupId>
             <artifactId>openml-utils</artifactId>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
This then allows the users to rely on a single openml api
version (that may be a superset usable by all used providers)
instead of 1 provider having internally a fixed openml api
version that is not good enough for all providers.

E.g.:
 * openml-api 0.2.2 has a new method
 * openml-provider-A depends on openml-api 0.2.2 and uses that method
 * openml-provider-B depends on openml-api 0.2.1 and does not care about that method

If openml-provider-B embeds openml-api (in that case 0.2.1) it can
'overtake' the openml-api 0.2.2 (that the user directly depends on)
and cause openml-provider-A to fail.