### PR TITLE
Remove travis comments on PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,6 @@ script:
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 
-notifications:
-    # enables comments in the branch with the CI results
-    webhooks: https://www.travisbuddy.com/
-
 before_deploy:
   # Clean up all target dirs created by mvn inside the container so that the deploy script works (permission errors)
   - docker exec -it test-container bash -v mvn -f /opt/openml/pom.xml clean


### PR DESCRIPTION
Travis comments make the PR timeline very noisy. At the same time, we still have PR checks that give us that information, so it's kinda redundant. 

note: We have also removed from the openml repo a while ago https://github.com/feedzai/feedzai-openml/pull/35