### PR TITLE
Bump OpenML API version to 1.0.1

### DIFF
--- a/openml-python-common/src/test/java/com/feedzai/openml/python/ClassificationPythonModelTest.java
+++ b/openml-python-common/src/test/java/com/feedzai/openml/python/ClassificationPythonModelTest.java
@@ -1,10 +1,17 @@
 /*
- * The copyright of this file belongs to Feedzai. The file cannot be
- * reproduced in whole or in part, stored in a retrieval system,
- * transmitted in any form, or by any means electronic, mechanical,
- * photocopying, or otherwise, without the prior permission of the owner.
+ * Copyright (c) 2019 Feedzai
  *
- * © 2019 Feedzai, Strictly Confidential
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
 
 package com.feedzai.openml.python;
@@ -23,6 +30,7 @@ import org.junit.Test;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
 
@@ -83,7 +91,8 @@ public class ClassificationPythonModelTest {
     public final void testInvalidClass() throws URISyntaxException, ExecutionException, InterruptedException {
         final Path modelPath = Paths.get(getClass().getResource("/dummy_model").toURI());
         final String id = "classificationModel";
-        final ImmutableList<FieldSchema> fields = ImmutableList.of(FIELD_SCHEMA, CATEGORICAL_FIELD_SCHEMA);
+        final List<FieldSchema> fields = ImmutableList.of(FIELD_SCHEMA, CATEGORICAL_FIELD_SCHEMA);
+        final String illegalTargetValue = "those";
         final DatasetSchema schema = new DatasetSchema(1, fields);
         final Random random = new Random();
 
@@ -94,7 +103,7 @@ public class ClassificationPythonModelTest {
 
             // Import the Classifier custom class and store an instance of it in a variable with the name passed in "id"
             jep.eval("from classifier import Classifier");
-            jep.eval(String.format("%s = Classifier()", id));
+            jep.eval(String.format("%s = Classifier('%s')", id, illegalTargetValue));
 
             return null;
         }).get();

--- a/openml-python-common/src/test/java/com/feedzai/openml/python/ClassificationPythonModelTest.java
+++ b/openml-python-common/src/test/java/com/feedzai/openml/python/ClassificationPythonModelTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * Tests the behaviour of a {@link ClassificationPythonModel}.
  *
  * @author Joao Sousa (joao.sousa@feedzai.com)
- * @since @@@feedzai.next.release@@@
  */
 public class ClassificationPythonModelTest {
 

--- a/openml-python-common/src/test/resources/dummy_model/classifier.py
+++ b/openml-python-common/src/test/resources/dummy_model/classifier.py
@@ -1,8 +1,12 @@
 class Classifier(object):
 
+    def __init__(self, target_value):
+        self.target_value = target_value
+        self.multiplier = [1, 0, 0]
+
     def classify(self, instances):
-        return 'randomClass'
+        return self.target_value
 
 
     def getClassDistribution(self, instances):
-        return [[1,0,0]] * len(instances)
+        return [self.multiplier] * len(instances)

--- a/openml-python-common/src/test/resources/dummy_model/classifier.py
+++ b/openml-python-common/src/test/resources/dummy_model/classifier.py
@@ -1,0 +1,8 @@
+class Classifier(object):
+
+    def classify(self, instances):
+        return 'randomClass'
+
+
+    def getClassDistribution(self, instances):
+        return [[1,0,0]] * len(instances)

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <assertj.version>3.7.0</assertj.version>
         <jackson.version>2.6.7</jackson.version>
         <jackson-databind.version>2.6.7</jackson-databind.version>
-        <openml-api.version>1.0.0</openml-api.version>
+        <openml-api.version>1.0.1</openml-api.version>
         <jep.version>3.7.0</jep.version>
     </properties>
 


### PR DESCRIPTION
Summary:
Since OpenML 1.0.0 had some missing changes, this commits bumps the version to 1.0.1 and adapts the code the new changes