### PR TITLE
Prepare code for more recent versions of Guava

### DIFF
--- a/openml-generic-python/pom.xml
+++ b/openml-generic-python/pom.xml
@@ -50,6 +50,11 @@
             <artifactId>auto-service</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>provided</scope>

--- a/openml-python-common/pom.xml
+++ b/openml-python-common/pom.xml
@@ -48,6 +48,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.feedzai</groupId>
             <artifactId>openml-utils</artifactId>
             <scope>test</scope>

--- a/openml-scikit/pom.xml
+++ b/openml-scikit/pom.xml
@@ -47,6 +47,11 @@
             <artifactId>auto-service</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.feedzai</groupId>
             <artifactId>openml-utils</artifactId>
             <type>test-jar</type>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.source>1.8</project.source>
-        <guava.version>18.0</guava.version>
         <commons-math3.version>3.3</commons-math3.version>
         <commons-lang3.version>3.7</commons-lang3.version>
         <commons-io.version>2.4</commons-io.version>
@@ -110,11 +109,13 @@
                 <scope>test</scope>
             </dependency>
 
-            <!--Guava-->
+            <!-- Use the same dependencies versions of openml-api -->
             <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${guava.version}</version>
+                <groupId>com.feedzai</groupId>
+                <artifactId>openml</artifactId>
+                <version>${openml-api.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
 
             <!--Logging -->


### PR DESCRIPTION
While upgrading guava to version 29-jre some methods where removed. Since we can't release a version with guava upgraded yet we can already remove the use of deprecated methods, and replace it with similar methods.

We also change the way that dependencies are managed to get the versions that openml-api uses.