### PR TITLE
pom: Bump OpenML-API

### DIFF
--- a/openml-python-common/pom.xml
+++ b/openml-python-common/pom.xml
@@ -68,5 +68,9 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <assertj.version>3.7.0</assertj.version>
         <jackson.version>2.6.7</jackson.version>
         <jackson-databind.version>2.6.7</jackson-databind.version>
-        <openml-api.version>1.0.3</openml-api.version>
+        <openml-api.version>1.1.0</openml-api.version>
         <jep.version>3.7.0</jep.version>
     </properties>
 


### PR DESCRIPTION
This commit upgrades OpenML-API dependency which use the Guava v25.1.